### PR TITLE
Feature/make psr7 params nullable typed

### DIFF
--- a/.github/workflows/WP_6_2.yaml
+++ b/.github/workflows/WP_6_2.yaml
@@ -1,4 +1,4 @@
-name: WordPress 6.0 Test Suite [PHP7.2-8.1]
+name: WP6.6 [PHP7.4-8.3] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -53,16 +53,12 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.0.0 --dev --no-update
-          && composer require roots/wordpress:6.0.0 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:6.0.0 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.2.* --dev --no-update
+          && composer require roots/wordpress:6.2.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.2.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.0
+      - name: Run Tests on Latest Version - WP6.2
         env:
           environment_github: true
         run: composer all
-
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.HTTP_CODCOV }}
-      

--- a/.github/workflows/WP_6_3.yaml
+++ b/.github/workflows/WP_6_3.yaml
@@ -1,4 +1,4 @@
-name: WordPress 5.9 Test Suite [PHP7.2-8.1]
+name: WP6.6 [PHP7.4-8.3] Tests
 
 on:
   push:
@@ -11,13 +11,12 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1']
-        mysql-versions: ['mysql:5.7']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
       mysql-service:
-        image: mysql:5.7
+        image: 'mysql:5.7'
         env:
           MYSQL_ROOT_PASSWORD: 'crab'
           MYSQL_DATABASE: pc_core_tests
@@ -54,12 +53,12 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:5.9.0 --dev --no-update
-          && composer require roots/wordpress:5.9.4 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:5.9.4 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.3.* --dev --no-update
+          && composer require roots/wordpress:6.3.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.3.* --dev --no-update
           && composer update --no-cache
-      
-      - name: Run Tests on WP5.9
+
+      - name: Run Tests on Latest Version - WP6.3
         env:
           environment_github: true
         run: composer all

--- a/.github/workflows/WP_6_4.yaml
+++ b/.github/workflows/WP_6_4.yaml
@@ -1,0 +1,64 @@
+name: WP6.4 [PHP7.4-8.2] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor 
+          && rm -rf composer.lock 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock 
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.4.* --dev --no-update
+          && composer require roots/wordpress:6.4.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.4.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on Latest Version - WP6.4
+        env:
+          environment_github: true
+        run: composer all

--- a/.github/workflows/WP_6_5.yaml
+++ b/.github/workflows/WP_6_5.yaml
@@ -1,0 +1,64 @@
+name: WP6.5 [PHP7.4-8.3] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor 
+          && rm -rf composer.lock 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock 
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.5.* --dev --no-update
+          && composer require roots/wordpress:6.5.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.5.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on Latest Version - WP6.5
+        env:
+          environment_github: true
+        run: composer all

--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -1,0 +1,64 @@
+name: WP6.6 [PHP7.4-8.4] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor 
+          && rm -rf composer.lock 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock 
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.6.* --dev --no-update
+          && composer require roots/wordpress:6.6.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.6.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on Latest Version - WP6.6
+        env:
+          environment_github: true
+        run: composer all

--- a/.github/workflows/WP_6_7.yaml
+++ b/.github/workflows/WP_6_7.yaml
@@ -1,4 +1,4 @@
-name: WordPress 6.1 Test Suite [PHP7.2-8.1]
+name: WP6.7 [PHP7.4-8.4] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -53,16 +53,16 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.0.0 --dev --no-update
-          && composer require roots/wordpress:6.1.1 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:6.1.1 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.7.* --dev --no-update
+          && composer require roots/wordpress:6.7.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.7.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.0
+      - name: Run Tests on Latest Version - WP6.7
         env:
           environment_github: true
         run: composer all
 
       - name: Codecov
         run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.HTTP_CODCOV }}
- 
+      

--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@
 Wrapper around Nyholm\Psr7 library with a few helper methods and a basic emitter. For use in WordPress during ajax calls.
 
 
-[![Latest Stable Version](http://poser.pugx.org/pinkcrab/http/v)](https://packagist.org/packages/pinkcrab/http)
-[![Total Downloads](http://poser.pugx.org/pinkcrab/http/downloads)](https://packagist.org/packages/pinkcrab/http)
-[![License](http://poser.pugx.org/pinkcrab/http/license)](https://packagist.org/packages/pinkcrab/http)
-[![PHP Version Require](http://poser.pugx.org/pinkcrab/http/require/php)](https://packagist.org/packages/pinkcrab/http)
+[![Latest Stable Version](https://poser.pugx.org/pinkcrab/http/v)](https://packagist.org/packages/pinkcrab/http)
+[![Total Downloads](https://poser.pugx.org/pinkcrab/http/downloads)](https://packagist.org/packages/pinkcrab/http)
+[![License](https://poser.pugx.org/pinkcrab/http/license)](https://packagist.org/packages/pinkcrab/http)
+[![PHP Version Require](https://poser.pugx.org/pinkcrab/http/require/php)](https://packagist.org/packages/pinkcrab/http)
 ![GitHub contributors](https://img.shields.io/github/contributors/Pink-Crab/HTTP?label=Contributors)
 ![GitHub issues](https://img.shields.io/github/issues-raw/Pink-Crab/HTTP)
 
-[![WordPress 6.1 Test Suite [PHP7.2-8.1]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_1.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_1.yaml)
+[![WordPress 6.7 Test Suite [PHP7.4-8.4]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_7.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_7.yaml)
+[![WordPress 6.6 Test Suite [PHP7.4-8.4]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_6.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_6.yaml)
+[![WordPress 6.5 Test Suite [PHP7.4-8.3]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_5.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_5.yaml)
+[![WordPress 6.4 Test Suite [PHP7.4-8.3]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_4.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_4.yaml)
+[![WordPress 6.3 Test Suite [PHP7.4-8.3]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_3.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_3.yaml)
+[![WordPress 6.2 Test Suite [PHP7.4-8.3]](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_2.yaml/badge.svg?branch=master)](https://github.com/Pink-Crab/HTTP/actions/workflows/WP_6_2.yaml)
+
 [![codecov](https://codecov.io/gh/Pink-Crab/HTTP/branch/master/graph/badge.svg?token=ZP2DNBV3MT)](https://codecov.io/gh/Pink-Crab/HTTP)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/HTTP/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/HTTP/?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3f2580ac743e2ec54542/maintainability)](https://codeclimate.com/github/Pink-Crab/HTTP/maintainability)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ $stream = HTTP_Helper::stream_from_scalar($data);
 http://www.opensource.org/licenses/mit-license.html  
 
 ## Change Log ##
+* 1.1.0 - Add nullable type hint to the reason phrase in the response and update dev dependencies
 * 1.0.0 - Removed HTTP::create_stream_with_json()
 * 0.2.6 - Readme changes
 * 0.2.5 - Removed object type hint for param in emit_response

--- a/composer.json
+++ b/composer.json
@@ -23,21 +23,27 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "phpstan/phpstan": "^1.0",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "php-stubs/wordpress-stubs": "^6.0 || ^5.9",
-        "roots/wordpress": "^6.1",
-        "wp-phpunit/wp-phpunit": "^6.1",
+        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpstan/phpstan": "1.*",
+        "szepeviktor/phpstan-wordpress": "<=1.3.2",
+        "php-stubs/wordpress-stubs": "6.7.*",
+        "roots/wordpress": "6.7.*",
+        "wp-phpunit/wp-phpunit": "6.7.*",
+
+        "phpcompatibility/php-compatibility": "*",
+        "wp-coding-standards/wpcs": "^3",
+        "squizlabs/php_codesniffer": "3.*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
-        "wp-coding-standards/wpcs": "*",
-        "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0",
+
+        "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0",
+        "roave/security-advisories": "dev-latest",
+
         "symfony/var-dumper": "*",
         "gin0115/wpunit-helpers": "~1",
         "vlucas/phpdotenv": "^5.4"
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "nyholm/psr7": "^1.3",
         "nyholm/psr7-server": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "phpstan/phpstan": "^1.0",
         "szepeviktor/phpstan-wordpress": "^1.0",
         "php-stubs/wordpress-stubs": "^6.0 || ^5.9",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,8 @@
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
 	</rule>
 
 	<!-- Add in some extra rules from other standards. -->

--- a/src/HTTP.php
+++ b/src/HTTP.php
@@ -47,6 +47,7 @@ class HTTP {
 	 *
 	 * @uses Psr17Factory::class
 	 * @uses ServerRequestCreator::class
+	 *
 	 * @return ServerRequestInterface
 	 */
 	public function request_from_globals(): ServerRequestInterface {
@@ -66,11 +67,13 @@ class HTTP {
 	 * Wrapper for making a PS7 request.
 	 *
 	 * @uses Nyholm\Psr7::Request()
-	 * @param string $method HTTP method
-	 * @param string|UriInterface $uri URI
-	 * @param array<string, string> $headers Request headers
-	 * @param string|resource|StreamInterface|null $body Request body
-	 * @param string $version Protocol version
+	 * @param string                               $method  HTTP method
+	 * @param string|UriInterface                  $uri     URI
+	 * @param array<string, string>                $headers Request headers
+	 * @param string|resource|StreamInterface|null $body    Request body
+	 * @param string                               $version Protocol version
+	 *
+	 * @return RequestInterface
 	 */
 	public function psr7_request(
 		string $method,
@@ -85,11 +88,12 @@ class HTTP {
 	/**
 	 * Returns a PS7 Response object.
 	 *
-	 * @param int $status
-	 * @param array<string, string> $headers
-	 * @param array<string, string>|string|resource|StreamInterface|null $body
-	 * @param string $version
-	 * @param string $reason
+	 * @param array<string, string>|string|resource|StreamInterface|null $body    The response body.
+	 * @param integer                                                    $status  The response status.
+	 * @param array<string, string>                                      $headers The response headers.
+	 * @param string                                                     $version The response version.
+	 * @param string|null                                                $reason  The response reason.
+	 *
 	 * @return ResponseInterface
 	 */
 	public function psr7_response(
@@ -97,7 +101,7 @@ class HTTP {
 		int $status = 200,
 		array $headers = array(),
 		string $version = '1.1',
-		string $reason = null
+		?string $reason = null
 	): ResponseInterface {
 		// Json Encode if body is array or object.
 		if ( is_array( $body ) || is_object( $body ) ) {
@@ -111,9 +115,10 @@ class HTTP {
 	/**
 	 * Returns a WP_Rest_Response
 	 *
-	 * @param int $status
-	 * @param array<string, string> $headers
-	 * @param mixed $data
+	 * @param array<string, string>|object|string|null $data    The response data.
+	 * @param integer                                  $status  The response status.
+	 * @param array<string, string>                    $headers The response headers.
+	 *
 	 * @return WP_HTTP_Response
 	 */
 	public function wp_response(
@@ -127,9 +132,11 @@ class HTTP {
 	/**
 	 * Emits either a PS7 or WP_HTTP Response.
 	 *
-	 * @param ResponseInterface|WP_HTTP_Response|object $response
+	 * @param ResponseInterface|WP_HTTP_Response|object $response The response to emit.
+	 *
 	 * @return void
-	 * @throws InvalidArgumentException
+	 *
+	 * @throws InvalidArgumentException If response is not a valid type.
 	 */
 	public function emit_response( $response ): void {
 
@@ -172,9 +179,7 @@ class HTTP {
 			as $name => $values ) {
 
 			// If values are an array, join.
-			$values = is_array( $values )
-				? join( ',', $values )
-				: (string) $values;
+			$values = is_array( $values ) ? join( ',', $values ) : (string) $values;
 
 			$response_header = sprintf( '%s: %s', $name, $values );
 			header( $response_header, false );
@@ -199,10 +204,7 @@ class HTTP {
 		// Append headers.
 		foreach ( $this->headers_with_json( $response->get_headers() )
 			as $name => $values ) {
-
-			$values = is_array( $values )
-				? join( ',', $values )
-				: (string) $values;
+			$values = is_array( $values ) ? join( ',', $values ) : (string) $values;
 
 			$header = sprintf( '%s: %s', $name, $values );
 
@@ -244,7 +246,7 @@ class HTTP {
 	/**
 	 * Wraps any value which can be json encoded in a StreamInterface
 	 *
-	 * @param string|int|float|object|array<mixed> $data
+	 * @param string|integer|float|object|array<mixed> $data
 	 * @return \Psr\Http\Message\StreamInterface
 	 */
 	public function stream_from_scalar( $data ): StreamInterface {

--- a/src/HTTP_Helper.php
+++ b/src/HTTP_Helper.php
@@ -70,11 +70,13 @@ class HTTP_Helper {
 	 * Wrapper for making a PS7 request.
 	 *
 	 * @uses Nyholm\Psr7::Request()
-	 * @param string $method HTTP method
-	 * @param string|UriInterface $uri URI
-	 * @param array<string, string> $headers Request headers
-	 * @param string|resource|StreamInterface|null $body Request body
-	 * @param string $version Protocol version
+	 * @param string                               $method  HTTP method
+	 * @param string|UriInterface                  $uri     URI
+	 * @param array<string, string>                $headers Request headers
+	 * @param string|resource|StreamInterface|null $body    Request body
+	 * @param string                               $version Protocol version
+	 *
+	 * @return RequestInterface
 	 */
 	public static function request(
 		string $method,
@@ -90,11 +92,12 @@ class HTTP_Helper {
 	/**
 	 * Returns a PS7 Response object.
 	 *
-	 * @param int $status
-	 * @param array<string, string> $headers
+	 * @param integer                                                    $status
+	 * @param array<string, string>                                      $headers
 	 * @param array<string, string>|string|resource|StreamInterface|null $body
-	 * @param string $version
-	 * @param string $reason
+	 * @param string                                                     $version
+	 * @param string|null                                                $reason
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function response(
@@ -102,7 +105,7 @@ class HTTP_Helper {
 		int $status = 200,
 		array $headers = array(),
 		string $version = '1.1',
-		string $reason = null
+		?string $reason = null
 	): ResponseInterface {
 		return static::get_http()
 			->psr7_response( $body, $status, $headers, $version, $reason );
@@ -111,9 +114,9 @@ class HTTP_Helper {
 	/**
 	 * Returns a WP_Rest_Response
 	 *
-	 * @param int $status
+	 * @param integer               $status
 	 * @param array<string, string> $headers
-	 * @param mixed $data
+	 * @param mixed                 $data
 	 * @return WP_HTTP_Response
 	 */
 	public static function wp_response(
@@ -128,7 +131,7 @@ class HTTP_Helper {
 	/**
 	 * Wraps any value which can be json encoded in a StreamInterface
 	 *
-	 * @param string|int|float|object|array<mixed> $value
+	 * @param string|integer|float|object|array<mixed> $value
 	 * @return StreamInterface
 	 */
 	public static function stream_from_scalar( $value ): StreamInterface {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,10 +28,16 @@ try {
 
 tests_add_filter(
 	'muplugins_loaded',
-	function() {
-
+	function () {
 	}
 );
+
+// if ( ! function_exists( 'xdebug_get_headers' ) ) {
+// 	function xdebug_get_headers() {
+// 		// Return the list of headers set by PHP
+// 		return headers_list();
+// 	}
+// }
 
 // Start up the WP testing environment.
 require getenv( 'WP_PHPUNIT__DIR' ) . '/includes/bootstrap.php';


### PR DESCRIPTION
This pull request includes several changes to update the WordPress test suite workflows and improve code consistency and documentation. The most important changes include renaming and updating workflow files, modifying dependencies in `composer.json`, and enhancing code documentation.

### Workflow Updates:
* Renamed and updated `.github/workflows/wp59.yaml` to `.github/workflows/WP_6_2.yaml`, changing the test suite name and PHP versions. [[1]](diffhunk://#diff-5acf4a5864790ebc132fa751b781166b9a3b25931f179e1a8fa99867f0b97dd4L1-R1) [[2]](diffhunk://#diff-5acf4a5864790ebc132fa751b781166b9a3b25931f179e1a8fa99867f0b97dd4L14-R19) [[3]](diffhunk://#diff-5acf4a5864790ebc132fa751b781166b9a3b25931f179e1a8fa99867f0b97dd4L57-R61)
* Renamed and updated `.github/workflows/WP_6_1.yaml` to `.github/workflows/WP_6_3.yaml`, changing the test suite name and PHP versions. [[1]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL1-R1) [[2]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL14-R14) [[3]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL56-L68)
* Added new workflow files for WordPress 6.4, 6.5, and 6.6 test suites with corresponding PHP versions. [[1]](diffhunk://#diff-ce57ec975114ddc4b08b136f4db30d1308586d2e699b4ccc92ce6a010610932dR1-R64) [[2]](diffhunk://#diff-5fa98a003c59edcd1530894286834a20fb1eabf791b21727c95b2732ecf2e43eR1-R64) [[3]](diffhunk://#diff-8fe27bfd0cbf5aa0550f2b4c148c09469cf56d2dfded379c3c325af84db9f59eR1-R64)
* Renamed and updated `.github/workflows/WP_6_0.yaml` to `.github/workflows/WP_6_7.yaml`, changing the test suite name and PHP versions. [[1]](diffhunk://#diff-040f9159a9043a1d76a22a9e16e39ee1eb4bcc50c3c77b5c10edb8b57727f770L1-R1) [[2]](diffhunk://#diff-040f9159a9043a1d76a22a9e16e39ee1eb4bcc50c3c77b5c10edb8b57727f770L14-R14) [[3]](diffhunk://#diff-040f9159a9043a1d76a22a9e16e39ee1eb4bcc50c3c77b5c10edb8b57727f770L56-R61)

### Dependency Updates:
* Updated `composer.json` to modify development dependencies and required PHP version.

### Documentation Updates:
* Updated badges and test suite references in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R153)
* Enhanced code documentation in `src/HTTP.php` by adding return types and improving docblocks. [[1]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6R50) [[2]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6R75-R76) [[3]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6L88-R104) [[4]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6L114-R121) [[5]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6L130-R139) [[6]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6L175-R182) [[7]](diffhunk://#diff-897552b608a8d837e4604e4a28fe8988c4c1b44a29990a852c8a4fed623910e6L202-R207)

### Code Quality:
* Updated `phpcs.xml` to exclude additional rules for better code quality management