### PR TITLE
Fix workflow titles

### DIFF
--- a/.github/workflows/WP_6_2.yaml
+++ b/.github/workflows/WP_6_2.yaml
@@ -1,4 +1,4 @@
-name: WP6.6 [PHP7.4-8.3] Tests
+name: WP6.2 [PHP7.4-8.3] Tests
 
 on:
   push:

--- a/.github/workflows/WP_6_3.yaml
+++ b/.github/workflows/WP_6_3.yaml
@@ -1,4 +1,4 @@
-name: WP6.6 [PHP7.4-8.3] Tests
+name: WP6.3 [PHP7.4-8.3] Tests
 
 on:
   push:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to correct the version names in their respective YAML files.

* [`.github/workflows/WP_6_2.yaml`](diffhunk://#diff-5acf4a5864790ebc132fa751b781166b9a3b25931f179e1a8fa99867f0b97dd4L1-R1): Changed the workflow name from "WP6.6 [PHP7.4-8.3] Tests" to "WP6.2 [PHP7.4-8.3] Tests".
* [`.github/workflows/WP_6_3.yaml`](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL1-R1): Changed the workflow name from "WP6.6 [PHP7.4-8.3] Tests" to "WP6.3 [PHP7.4-8.3] Tests".